### PR TITLE
Deprecate component

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -5,7 +5,7 @@
 		"origamiCategory": "components",
 		"origamiVersion": 1,
 		"support": "https://github.com/Financial-Times/o-header--theme-ic/issues",
-		"supportStatus": "active",
+		"supportStatus": "deprecated",
 		"browserFeatures": {},
 		"ci": {
 			"circle": "https://circleci.com/api/v1/project/Financial-Times/o-header--theme-ic"


### PR DESCRIPTION
Markit and IC have now decided _not_ to use this header and are instead getting the header and footer via a JS endpoint, so we can deprecate this module.